### PR TITLE
deathtoll.py focused on evolution of deaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Covid-19 interactive visualizations to understand the evolution of the illness.
 
 # Installation
 
-This project had been tested with python 3.6, so it's better to have an environment with this version of python to make it work.
+This project had been tested with python 3.6, so it's recommended to have an environment with this version of python to make it work.
 
 As this package has `setup.py` aligned with `requirements.txt`, you only need to clone this repository and execute `pip install .` in the root of the project.
 
-It's better if you have an isolated environment activated before doing pip install (conda, venv, pipenv...).
+It's suggested to have an isolated environment activated before doing pip install (conda, venv, pipenv...).
 
 # How To Run?
 
 Once you have installed all of the requirements, you run the app with the command `streamlit run app.py` and automatically **streamlit** will open your navigator (localhost, port 8501 by default) and the app is ready, you can play with it!
 
 Note: This is an experiment, if you encounter with any issue, please let me know about it.
-Note (2): You can try also `streamlit run deathtoll.py`, focused on death trends, as confirmed "cases" depend a lot on the number of tests performed per country.
+You can try also `streamlit run deathtoll.py`, focused on death trends, as confirmed "cases" depend a lot on the number of tests performed per country.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coronavirus Disease (COVID-19) Evolution :hospital:
 
-Covid-19 interactive visualizations to understand the evolution of the illness. 
+Covid-19 interactive visualizations to understand the evolution of the illness.
 
 ![Virus](https://media.giphy.com/media/vO2ByH5dWCJEc/giphy.gif)
 
@@ -18,4 +18,5 @@ It's better if you have an isolated environment activated before doing pip insta
 
 Once you have installed all of the requirements, you run the app with the command `streamlit run app.py` and automatically **streamlit** will open your navigator (localhost, port 8501 by default) and the app is ready, you can play with it!
 
-Note: This is an experiment, if you encounter with any issue, please let me know about it 
+Note: This is an experiment, if you encounter with any issue, please let me know about it.
+Note (2): You can try also `streamlit run deathtoll.py`, focused on death trends, as confirmed "cases" depend a lot on the number of tests performed per country.

--- a/deathtoll.py
+++ b/deathtoll.py
@@ -36,11 +36,11 @@ st.title(f'Coronavirus Disease (COVID-19) Evolution :hospital:')
 st.text('The data is collected from Johns Hopkins University\'s repository')
 
 
-st.markdown('Fork of https://github.com/sergiocalde94/COVID-19-Evolution, but with focus on death trends only. '
-'Considering that confirmed "cases" depend a lot on the number of tests performed per country. '
-'And tests depends also on availability of resources and defined protocols. '
-' More data on this topic: https://ourworldindata.org/coronavirus-testing-source-data '
-)
+st.markdown('Fork of https://github.com/sergiocalde94/COVID-19-Evolution, great job from my colleague @sergiocalde94. '
+''
+'Now adapted to focus on death trends. Considering that confirmed "cases" depend a lot on the number of tests performed per country, their availability and the defined protocols. '
+'More data on testing statistics per country: [ourworldindata](https://ourworldindata.org/coronavirus-testing-source-data), '
+'[worldometer](https://www.worldometers.info/coronavirus/covid-19-testing/)')
 
 plot_figure = plot_provinces_map_animated(df_all_cases_provinces)
 
@@ -64,7 +64,7 @@ min_number_cases = st.slider('Minimum number of deaths?',
 df_all_cases_countries_from_case_n = (
     format_data_from_case_n(df_all_cases_countries,
                             groupby='country_or_region',
-                            n=min_number_cases)
+                            n=min_number_cases, mytype='Deaths')
 )
 
 

--- a/deathtoll.py
+++ b/deathtoll.py
@@ -1,0 +1,124 @@
+import streamlit as st
+import locale
+
+from helpers.constants import (CASE_TYPES,
+                               FILLNA,
+                               ID_VARS,
+                               URL_DATA,
+                               VALUE_NAME,
+                               VAR_NAME)
+from helpers.utils import (read_and_format_covid_datasets,
+                           union_all_cases_types,
+                           format_data_from_case_n,
+                           max_summary_by_country)
+from helpers.plotting import (plot_provinces_map_animated,
+                              plot_figure_countries_facet,
+                              plot_china_vs_europe_vs_us)
+
+
+locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+
+df_confirmed, df_deaths, df_recovered = (
+    read_and_format_covid_datasets(URL_DATA,
+                                   CASE_TYPES,
+                                   ID_VARS,
+                                   VAR_NAME,
+                                   VALUE_NAME)
+)
+
+df_all_cases = union_all_cases_types(df_confirmed, df_deaths, df_recovered)
+
+df_all_cases_provinces = (df_all_cases
+                          .fillna({'province_or_state': FILLNA})
+                          .sort_values(['date', 'type_order']))
+
+st.title(f'Coronavirus Disease (COVID-19) Evolution :hospital:')
+st.text('The data is collected from Johns Hopkins University\'s repository')
+
+
+st.markdown('Fork of https://github.com/sergiocalde94/COVID-19-Evolution, but with focus on death trends only. '
+'Considering that confirmed "cases" depend a lot on the number of tests performed per country. '
+'And tests depends also on availability of resources and defined protocols. '
+' More data on this topic: https://ourworldindata.org/coronavirus-testing-source-data '
+)
+
+plot_figure = plot_provinces_map_animated(df_all_cases_provinces)
+
+st.subheader('Province/State Data Animated By Date :earth_africa:')
+
+st.plotly_chart(plot_figure)
+
+df_all_cases_countries = (df_all_cases_provinces
+                          .groupby(['country_or_region', 'date', 'type'])
+                          .agg(dict(cases='sum', population='first'))
+                          .reset_index())
+
+st.subheader('Country/Region Data To Compare :cityscape:')
+
+min_number_cases = st.slider('Minimum number of deaths?',
+                             min_value=1,
+                             max_value=400,
+                             value=100,
+                             step=10)
+
+df_all_cases_countries_from_case_n = (
+    format_data_from_case_n(df_all_cases_countries,
+                            groupby='country_or_region',
+                            n=min_number_cases)
+)
+
+
+countries_to_plot = st.multiselect(
+    'Take one/various countries to plot the evolution of that country',
+    sorted(df_all_cases_countries_from_case_n['country_or_region'].unique()),
+    default=['China','Italy','Spain','US']
+)
+
+df_all_cases_countries_from_case_n_subset = (
+    df_all_cases_countries_from_case_n[
+        df_all_cases_countries_from_case_n['country_or_region']
+        .isin(countries_to_plot)
+    ]
+)
+
+if countries_to_plot:
+    type_graph = st.radio(
+        'What type of graph do you prefer?',
+        (f'Cumulative deaths from death {min_number_cases}',
+         f'New deaths per day from death {min_number_cases}'))
+
+    st.warning(
+        'Be careful when comparing two countries with very diferent population!'
+    )
+
+    log_scale_countries = st.checkbox('Log Scale Countries Comparation')
+
+    population_weighting = st.checkbox(
+        'Weighting By Population (Cases By 1 Million Population)'
+    )
+
+    if population_weighting:
+        df_all_cases_countries_from_case_n_subset['cases'] = (
+                df_all_cases_countries_from_case_n_subset['cases']
+                / df_all_cases_countries_from_case_n_subset['population']
+                * 1e6
+        )
+    cumulative = (type_graph == f'Cumulative deaths from death {min_number_cases}')
+    if cumulative:
+        df_countries_from_case_n_info = (
+            max_summary_by_country(
+                df_all_cases_countries_from_case_n_subset,
+                columns=['cases', f'days_from_{min_number_cases}']
+            )
+        )
+
+    figure = plot_figure_countries_facet(
+                df_all_cases_countries_from_case_n_subset,
+                population_type='country_or_region',
+                min_number_cases=min_number_cases,
+                log_scale=log_scale_countries,
+                cumulative=cumulative,
+                mytype='Deaths'
+    )
+
+    st.plotly_chart(figure)

--- a/deathtoll.py
+++ b/deathtoll.py
@@ -36,7 +36,7 @@ st.title(f'Coronavirus Disease (COVID-19) Evolution :hospital:')
 st.text('The data is collected from Johns Hopkins University\'s repository')
 
 
-st.markdown('Fork of https://github.com/sergiocalde94/COVID-19-Evolution, great job from my colleague @sergiocalde94. '
+st.markdown('Fork of https://github.com/sergiocalde94/COVID-19-Evolution, great job from my colleague [@sergiocalde94](https://twitter.com/sergiocalde94). '
 ''
 'Now adapted to focus on death trends. Considering that confirmed "cases" depend a lot on the number of tests performed per country, their availability and the defined protocols. '
 'More data on testing statistics per country: [ourworldindata](https://ourworldindata.org/coronavirus-testing-source-data), '
@@ -58,7 +58,7 @@ st.subheader('Country/Region Data To Compare :cityscape:')
 min_number_cases = st.slider('Minimum number of deaths?',
                              min_value=1,
                              max_value=400,
-                             value=100,
+                             value=10,
                              step=10)
 
 df_all_cases_countries_from_case_n = (
@@ -122,3 +122,8 @@ if countries_to_plot:
     )
 
     st.plotly_chart(figure)
+
+st.markdown('More info: ')
+st.markdown('* mortality rate estimation and age distribution: https://medium.com/@andreasbackhausab/coronavirus-why-its-so-deadly-in-italy-c4200a15a7bf, https://www.epicentro.iss.it/coronavirus/bollettino/Infografica_17marzo%20ITA.pdf')
+st.markdown('* epidemic simulator: https://gabgoh.github.io/COVID/index.html')
+st.markdown('* Dashboard of the COVID-19 Virus Outbreak in Singapore, with detail of all confirmed cases: https://co.vid19.sg/dashboard')

--- a/helpers/plotting.py
+++ b/helpers/plotting.py
@@ -89,6 +89,30 @@ def plot_figure_countries_facet_new_cases_per_day(df_countries: pd.DataFrame,
         .for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1]))
     )
 
+# Adaptation to focus on a given type of cases, compliant with cumulative or cases per day
+def plot_figure_countries_facet(df_countries: pd.DataFrame,
+                                           population_type: str,
+                                           min_number_cases: int,
+                                           log_scale: bool, cumulative: bool, mytype: str) -> Figure:
+    df_countries_copy = df_countries.copy()
+    if cumulative == False:
+        df_countries_copy['cases'] = (
+            df_countries_copy
+            .groupby(['country_or_region', 'type'])
+            .cases
+            .transform(
+                lambda group: group.rolling(2, min_periods=1).apply(
+                    lambda x: x if len(x) == 1 else x.diff().iloc[1]
+                    )
+                    )
+                    )
+    df_countries_copy[mytype] = df_countries_copy['cases']
+    fig = (px.line(df_countries_copy[df_countries_copy['type']==mytype],
+             x=f'days_from_{min_number_cases}', y=mytype,
+             color='country_or_region',
+             log_y=log_scale).for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1])))
+    return fig
+
 
 def plot_china_vs_europe_vs_us(df_provinces: pd.DataFrame,
                                min_number_cases: int,

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -124,6 +124,41 @@ def format_data_from_case_n(df: pd.DataFrame,
 
     return df_merged_filtered
 
+## Adaptation to focus only on the given type, for instance 'Deaths' instead of 'Confirmed'
+@st.cache
+def format_data_from_case_n(df: pd.DataFrame,
+                            groupby: str,
+                            n: int, mytype: str) -> pd.DataFrame:
+    first_date_grouped = (
+        df[(df['type'] == mytype) & (df['cases'] >= n)]
+        .groupby(groupby)
+        .date
+        .first()
+        .reset_index()
+        .rename(columns=dict(date=f'date_{n}'))
+        .assign(**{f'days_from_{n}': lambda _: 1})
+    )
+
+    df_merged = df.merge(first_date_grouped,
+                         on=groupby,
+                         how='left')
+
+    df_merged_filtered = (
+        df_merged[df_merged['date'] >= df_merged[f'date_{n}']].copy()
+    )
+
+    df_merged_filtered[f'days_from_{n}'] = (df_merged_filtered[f'days_from_{n}']
+                                            .fillna(1))
+
+    df_merged_filtered[f'days_from_{n}'] = (
+        df_merged_filtered
+        .groupby([groupby, 'type'])
+        [f'days_from_{n}']
+        .transform('cumsum')
+    )
+
+    return df_merged_filtered
+
 
 def max_summary_by_country(df: pd.DataFrame, columns: [str]) -> pd.DataFrame:
     return (df

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -150,6 +150,8 @@ def format_data_from_case_n(df: pd.DataFrame,
     df_merged_filtered[f'days_from_{n}'] = (df_merged_filtered[f'days_from_{n}']
                                             .fillna(1))
 
+    df_merged_filtered = df_merged_filtered.astype({'date': 'datetime64[ns]'}).sort_values(by=[groupby, 'type', 'date']).reset_index()
+
     df_merged_filtered[f'days_from_{n}'] = (
         df_merged_filtered
         .groupby([groupby, 'type'])


### PR DESCRIPTION
Suggested changes:
- deathtoll.py, focused on death trends, as confirmed "cases" depend a lot on the number of tests performed per country.With some links too I consider interesting.
- adapted plot_figure_countries_facet in helpers/plotting.py, allowed to filter only a given type of cases, as only 'Deaths' as used by deathtoll.py. And compliant with both cumulative or cases per day
- minor changes in README.md

Thanks, and great job @sergiocalde94!